### PR TITLE
First attempt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,17 @@ PROJECT = esdl2
 SDL2_LIBS_FILTER_OUT = -Wl,--no-undefined
 SDL2_LIBS = $(filter-out $(SDL2_LIBS_FILTER_OUT),$(shell sdl2-config --static-libs))
 
-C_SRC_OPTS = $(shell sdl2-config --cflags) $(SDL2_LIBS) -lSDL2_image
+ifeq ($(OS),Windows_NT)
+	CC_OPTS = ""
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		CC_OPTS = -undefined dynamic_lookup
+    	endif
+endif
+
+
+C_SRC_OPTS = $(shell sdl2-config --cflags) $(SDL2_LIBS) -lSDL2_image  $(CC_OPTS)
 
 include erlang.mk
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ PROJECT = esdl2
 SDL2_LIBS_FILTER_OUT = -Wl,--no-undefined
 SDL2_LIBS = $(filter-out $(SDL2_LIBS_FILTER_OUT),$(shell sdl2-config --static-libs))
 
+C_SRC_OPTS = $(shell sdl2-config --cflags) $(SDL2_LIBS) -lSDL2_image
+
 ifeq ($(OS),Windows_NT)
 	CC_OPTS = ""
 else

--- a/c_src/esdl2.c
+++ b/c_src/esdl2.c
@@ -13,6 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include "esdl2.h"
+#include "nif_headers.h"
 #include <sys/queue.h>
 
 NIF_ATOMS(NIF_ATOM_DECL)

--- a/c_src/nif_headers.h
+++ b/c_src/nif_headers.h
@@ -1,0 +1,12 @@
+ 
+#ifndef __NIF_HEADER_H__
+#define __NIF_HEADER_H__
+
+
+ERL_NIF_TERM blend_mode_to_atom  (int id);
+ERL_NIF_TERM atom_to_blend_mode( ErlNifEnv *e, ERL_NIF_TERM t, SDL_BlendMode *id);
+ERL_NIF_TERM atom_to_bool(ErlNifEnv *e, ERL_NIF_TERM t, SDL_bool *b );
+
+void nif_destroy_main_thread(void* void_st);
+
+#endif

--- a/c_src/nif_helpers.c
+++ b/c_src/nif_helpers.c
@@ -16,8 +16,8 @@
 #include <sys/queue.h>
 #include <stdarg.h>
 
-extern atom_ok;
-extern atom__nif_thread_ret_;
+extern int atom_ok;
+extern int atom__nif_thread_ret_;
 
 typedef struct nif_thread_message {
 	TAILQ_ENTRY(nif_thread_message) next_entry;

--- a/c_src/sdl_texture.c
+++ b/c_src/sdl_texture.c
@@ -13,6 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include "esdl2.h"
+#include "nif_headers.h"
 
 void dtor_Texture(ErlNifEnv* env, void* obj)
 {

--- a/c_src/sdl_window.c
+++ b/c_src/sdl_window.c
@@ -13,6 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include "esdl2.h"
+#include "nif_headers.h" 
 
 void dtor_Window(ErlNifEnv* env, void* obj)
 {


### PR DESCRIPTION
Gday Essen,

Pretty sure that this isn't going to be up to snuff, but perhaps you can point me in the right direction if its not good enough.

These two commits are required to build on a modern OS X implementation. Apple in their infinite wisdom have made /usr/bin/gcc actually clang/llvm so I can't "nicely" use the $(CC) detection.. instead I'm simply blanketing all systems reporting as darwin to use this flag.

The function declarations are also required to be specified before use, or clang has a bad day.

I welcome feedback, and I'm sure that this is not the best way to go about it, its just where I"m stuck for now.  Rather than waste my research I figured I can put it here, and maybe you (or someone else) can point me in the right direction to detecting clang without suck.

Thanks.