### PR TITLE
OSX fix joining main thread with calling thread when exiting

### DIFF
--- a/c_src/nif_helpers.c
+++ b/c_src/nif_helpers.c
@@ -185,10 +185,14 @@ void nif_destroy_main_thread(void* void_st)
 	nif_thread_message* msg = nif_thread_message_alloc(NULL, NULL, NULL);
 
 	nif_thread_send(st, msg);
-	enif_thread_join(st->tid, NULL);
+	#if defined(__APPLE__) && defined(__MACH__)
+   		erl_drv_stolen_main_thread_join(st->tid, NULL);
+  	#else
+		enif_thread_join(st->tid, NULL);
+  	#endif
 
-	enif_cond_destroy(st->cond);
 	enif_mutex_destroy(st->lock);
+	enif_cond_destroy(st->cond);
 	enif_free(st->mailbox);
 	enif_free(st);
 }


### PR DESCRIPTION
Current commit fixes a segfault when terminating the app in OSX. 
Continue to be issues with dtor_Texture that generates a different segfault in current demos, so to be able to replicate the segfault fixed by this commit, limit the code to create a window and exit.
On OSX we have to use erl_drv_steal_main_thread, a not documented function to run SDL2 in main thread. In the same way, to join it again with the calling thread when exiting, we have to invoke  erl_drv_stolen_main_thread_join instead of enif_thread_join like in Windows/Linux.
