### PR TITLE
SDL2 resource destructors segfaults fix 

### DIFF
--- a/c_src/sdl_gl.c
+++ b/c_src/sdl_gl.c
@@ -14,10 +14,16 @@
 
 #include "esdl2.h"
 
+
+NIF_CAST_HANDLER(thread_destroy_GLContext)
+{
+	SDL_GL_DeleteContext(NIF_RES_GET(GLContext, args[0]));
+        enif_release_resource(NIF_RES_DEP(GLContext, args[0]));
+}
+
 void dtor_GLContext(ErlNifEnv* env, void* obj)
 {
-	SDL_GL_DeleteContext(NIF_RES_GET(GLContext, obj));
-	enif_release_resource(NIF_RES_DEP(GLContext, obj));
+	nif_thread_cast(env,thread_destroy_GLContext,1,obj);
 }
 
 // gl_create_context

--- a/c_src/sdl_renderer.c
+++ b/c_src/sdl_renderer.c
@@ -14,10 +14,14 @@
 
 #include "esdl2.h"
 
+NIF_CAST_HANDLER(thread_destroy_renderer)
+{
+ 	SDL_DestroyRenderer(NIF_RES_GET(Renderer, args[0]));
+        enif_release_resource(NIF_RES_DEP(Renderer, args[0]));
+}
 void dtor_Renderer(ErlNifEnv* env, void* obj)
 {
-	SDL_DestroyRenderer(NIF_RES_GET(Renderer, obj));
-	enif_release_resource(NIF_RES_DEP(Renderer, obj));
+	nif_thread_cast(env,thread_destroy_renderer,1,obj);
 }
 
 #define RENDERER_FLAGS(F) \

--- a/c_src/sdl_surface.c
+++ b/c_src/sdl_surface.c
@@ -15,9 +15,13 @@
 #include "esdl2.h"
 #include "SDL_image.h"
 
+NIF_CAST_HANDLER(thread_destroy_surface)
+{
+	SDL_FreeSurface(NIF_RES_GET(Surface, args[0]));
+}
 void dtor_Surface(ErlNifEnv* env, void* obj)
 {
-	SDL_FreeSurface(NIF_RES_GET(Surface, obj));
+	nif_thread_cast(env,thread_destroy_surface,1,obj);
 }
 
 // img_load

--- a/c_src/sdl_texture.c
+++ b/c_src/sdl_texture.c
@@ -17,9 +17,13 @@
 NIF_ATOM_TO_ENUM_FUNCTION_DECL(atom_to_blend_mode, SDL_BlendMode)
 NIF_ENUM_TO_ATOM_FUNCTION_DECL(blend_mode_to_atom, SDL_BlendMode)
 
+NIF_CAST_HANDLER(thread_destroy_texture)
+{
+	SDL_DestroyTexture(NIF_RES_GET(Texture, args[0]));
+}
 void dtor_Texture(ErlNifEnv* env, void* obj)
 {
-	SDL_DestroyTexture(NIF_RES_GET(Texture, obj));
+	nif_thread_cast(env,thread_destroy_texture,1,obj);
 }
 
 // create_texture_from_surface

--- a/c_src/sdl_window.c
+++ b/c_src/sdl_window.c
@@ -16,9 +16,13 @@
 
 NIF_ATOM_TO_ENUM_FUNCTION_DECL(atom_to_bool, SDL_bool)
 
+NIF_CAST_HANDLER(thread_destroy_window)
+{
+	SDL_DestroyWindow(NIF_RES_GET(Window, args[0]));
+}
 void dtor_Window(ErlNifEnv* env, void* obj)
 {
-	SDL_DestroyWindow(NIF_RES_GET(Window, obj));
+	nif_thread_cast(env,thread_destroy_window,1,obj);
 }
 
 #define WINDOW_FLAGS(F) \


### PR DESCRIPTION
Fix for random segfaults in SDL destructors. Discussed in issue #2.
SDL_DestroyXXXX and SDL_FreeSurface should be called from the main thread due to the lack of multithreading support in SDL2.
Probably not the cleanest or more elegant implementation to merge, but in the worst case, useful as proof of concept solving these segfaults.
