### PR TITLE
Added minimal rebar3 configuration file.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,1 @@
+{post_hooks, [{compile, "make"}]}.


### PR DESCRIPTION
This adds super-minimal rebar3 support -- basically just calls `make`. However, this does let LFE libraries easily add esdl2 to projects as a dep (which use rebar3 in their tool chain).
